### PR TITLE
Fix grammatical error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::io::{self, Read};
 
 enum CLIError {
-    TooLittleArguments,
+    TooFewArguments,
     InvalidSubcommand(String),
     StdInUnreadable,
     DecodingError,
@@ -15,7 +15,7 @@ enum CLIError {
 impl std::fmt::Debug for CLIError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            Self::TooLittleArguments => write!(f, "Too little arguments provided"),
+            Self::TooFewArguments => write!(f, "Not enough arguments provided"),
 
             Self::InvalidSubcommand(cmd) => write!(f, "Invalid subcommand provided: \"{}\"", cmd),
 
@@ -28,12 +28,12 @@ impl std::fmt::Debug for CLIError {
 
 fn main() -> Result<(), CLIError> {
     if std::env::args().count() < 2 {
-        return Err(CLIError::TooLittleArguments);
+        return Err(CLIError::TooFewArguments);
     }
 
     let subcommand = std::env::args()
         .nth(1)
-        .ok_or_else(|| CLIError::TooLittleArguments)?;
+        .ok_or_else(|| CLIError::TooFewArguments)?;
 
     let input = read_stdin()?;
 


### PR DESCRIPTION
The code uses `TooLittleArguments` as an error, but Argument in this case is countable as it refers to the _amount_ of arguments not the _size_. When referring to a countable noun few should be used, so change the error to `TooFewArguments` 

While I personally would prefer to call the error `NotEnoughArguments` this change is smaller and follows the same style.

(If merged, you likely want to update the article too)