### PR TITLE
improvement: improve the output result

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This project is built and run using cargo.
 
 ```bash
 # encoding
-echo "fluffy pancakes" | cargo run -- encode
+echo 'fluffy pancakes' | cargo run -- encode
 > Zmx1ZmZ5IHBhbmNha2Vz
 
 # and the reverse
-echo "Zmx1ZmZ5IHBhbmNha2Vz" | cargo run -- decode
+echo 'Zmx1ZmZ5IHBhbmNha2Vz' | cargo run -- decode
 > fluffy pancakes
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), CLIError> {
         cmd => Err(CLIError::InvalidSubcommand(cmd.to_string())),
     }?;
 
-    print!("{}", output);
+    println!("{}", output);
 
     Ok(())
 }
@@ -64,8 +64,7 @@ fn encode(input: &String) -> String {
 fn decode(input: &String) -> Result<String, CLIError> {
     let decoded = decoder::decode(input).map_err(|_| CLIError::DecodingError)?;
 
-    let decoded_as_string = std::str::from_utf8(&decoded)
-        .map_err(|_| CLIError::DecodingError)?;
+    let decoded_as_string = std::str::from_utf8(&decoded).map_err(|_| CLIError::DecodingError)?;
 
     Ok(decoded_as_string.to_owned())
 }


### PR DESCRIPTION
## Motivation

1. Exclamation mark is not treated as text in double-quotes in the echo command. It is therefore recommended to use single quotes. See this answer for [details](https://stackoverflow.com/a/32730888/12119348).
    ![image](https://user-images.githubusercontent.com/38807139/132732016-e950d409-ab1e-4f2a-88fa-909e5c9af7a3.png)

2. The `print!` macro will print a percentage sign when binary completes, because of [`PROMPT_SP`](https://superuser.com/questions/645599/why-is-a-percent-sign-appearing-before-each-prompt-on-zsh-in-windows/645612#645612). Considering that not everyone knows this and will take it as part of the result, I think it's better to use `println!` instead.
![image](https://user-images.githubusercontent.com/38807139/132732238-a1fd8369-1679-4170-8f6b-7b1a9a014774.png)
